### PR TITLE
Run the ingestion workflow monthly via GitHub Actions

### DIFF
--- a/.github/workflows/monthly-pipeline.yml
+++ b/.github/workflows/monthly-pipeline.yml
@@ -1,0 +1,81 @@
+name: Monthly data refresh
+
+on:
+  schedule:
+    - cron: '0 9 15 * *'  # dia 15 às 09:00 UTC = 06:00 BRT
+  workflow_dispatch:
+    inputs:
+      badge_month:
+        description: 'Mês do badge no formato YYYY/MM (padrão: mês corrente em UTC)'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: monthly-pipeline
+  cancel-in-progress: false
+
+env:
+  GCP_PROJECT: cloud-cnpj
+  GCP_REGION: us-central1
+  GCP_WORKFLOW: cloud-cnpj
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Trigger workflow execution
+        env:
+          WORKFLOW_CONFIG: ${{ secrets.CNPJ_WORKFLOW_CONFIG }}
+        run: |
+          EXECUTION=$(gcloud workflows execute "$GCP_WORKFLOW" \
+            --project="$GCP_PROJECT" \
+            --location="$GCP_REGION" \
+            --data="$WORKFLOW_CONFIG" \
+            --format='value(name)')
+          echo "Execução iniciada: \`$EXECUTION\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Acompanhe em https://console.cloud.google.com/workflows/workflow/$GCP_REGION/$GCP_WORKFLOW/executions?project=$GCP_PROJECT" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Update data updated badge
+        env:
+          BADGE_MONTH_INPUT: ${{ inputs.badge_month }}
+        run: |
+          MONTH="$BADGE_MONTH_INPUT"
+          if [ -z "$MONTH" ]; then
+            MONTH=$(date -u +%Y/%m)
+          elif ! echo "$MONTH" | grep -Eq '^[0-9]{4}/[0-9]{2}$'; then
+            echo "badge_month inválido: '$MONTH' (esperado YYYY/MM)" >&2
+            exit 1
+          fi
+          sed -i -E "s#(Dados_Atualizados-)[0-9]{4}/[0-9]{2}(-green)#\1${MONTH}\2#" README.md
+          sed -i -E "s#(Data_Updated-)[0-9]{4}/[0-9]{2}(-green)#\1${MONTH}\2#" README_en.md
+          echo "BADGE_MONTH=$MONTH" >> "$GITHUB_ENV"
+
+      - name: Commit badge update
+        run: |
+          if git diff --quiet -- README.md README_en.md; then
+            echo "Badge já estava em $BADGE_MONTH, nada a commitar."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md README_en.md
+          git commit -m "chore: update data updated badge to $BADGE_MONTH"
+          git push

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -5,8 +5,11 @@ Este é o orquestrador de tarefas do projeto, criado a partir do [Google Workflo
 ## 🏗 Estrutura
 
 ```
-├── cloud-cnpj.yaml   # Fluxo de orquestração de tarefas
-├── deploy.sh         # Script para criação do workflow
+├── cloud-cnpj.yaml    # Fluxo de orquestração de tarefas
+├── alert-policy.yaml  # Política de alerta por e-mail em caso de falha
+├── deploy.sh          # Script para criação do workflow
+├── deploy-alerts.sh   # Script para criação do alerta
+├── deploy-wif.sh      # Script para autenticação do GitHub Actions no GCP
 ├── README.md
 ```
 
@@ -50,7 +53,8 @@ Novamente, caso ainda não tenha verificado, certifique-se de possuir o [Google 
 gcloud workflows execute $FLOW_NAME \
     --location=$LOCATION \
     --data='{
-      "job_name": $JOB_NAME,
+      "ingestion_job_name": $INGESTION_JOB_NAME,
+      "use_job_name": $USE_JOB_NAME,
       "location": $LOCATION,
       "project_id": $PROJECT_ID,
       "slack_webhook_url": $SLACK_WEBHOOK_URL,
@@ -72,6 +76,48 @@ gcloud workflows execute $FLOW_NAME \
       ]
     }'
 ```
+
+O campo `slack_webhook_url` é opcional: quando ausente ou vazio, nenhuma notificação externa é enviada, e uma eventual falha no envio nunca interrompe a execução.
+
+
+## 🤖 Execução automática
+
+O workflow é disparado uma vez por mês pelo GitHub Actions, através de [`monthly-pipeline.yml`](../.github/workflows/monthly-pipeline.yml), no dia 15 às 09:00 UTC (06:00 BRT). O job apenas dispara a execução — que pode levar horas — e encerra, atualizando na sequência o badge de dados atualizados no [`README.md`](../README.md) e no [`README_en.md`](../README_en.md) com um commit automático.
+
+Para disparar sob demanda:
+
+```
+gh workflow run monthly-pipeline.yml
+gh workflow run monthly-pipeline.yml -f badge_month=2026/07   # forçando o mês do badge
+```
+
+### Configuração
+
+A autenticação usa [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation), sem chaves de longa duração: a cada execução o GitHub emite um token OIDC que o Google troca por credenciais temporárias. Execute o script [`deploy-wif.sh`](./deploy-wif.sh), que cria a service account, o pool, o provider OIDC e as permissões, e ao final imprime os comandos dos segredos.
+
+O acesso é restrito a este repositório em duas camadas: o provider só aceita tokens cujo `assertion.repository` seja `Bruno-Furtado/cloud-cnpj`, e a permissão de personificar a service account é concedida apenas ao `principalSet` desse mesmo repositório. Forks não conseguem se autenticar.
+
+São necessários três segredos:
+
+| Secret | Conteúdo |
+|--------|----------|
+| `GCP_WIF_PROVIDER` | Caminho completo do provider (impresso pelo `deploy-wif.sh`) |
+| `GCP_SA_EMAIL` | E-mail da service account (impresso pelo `deploy-wif.sh`) |
+| `CNPJ_WORKFLOW_CONFIG` | O JSON passado em `--data` na seção anterior |
+
+```
+gh secret set CNPJ_WORKFLOW_CONFIG < /tmp/payload.json
+rm /tmp/payload.json
+```
+
+A role `roles/workflows.invoker` é suficiente: quem chama o Cloud Run Job e os Data Transfers é a service account do próprio workflow.
+
+
+## 🔔 Alertas
+
+Como o job do GitHub Actions encerra assim que dispara a execução, o acompanhamento acontece pelo Google Cloud Monitoring: qualquer log com severidade `ERROR` no workflow — falha do Cloud Run Job, falha de um Data Transfer ou erro da própria execução — gera um e-mail.
+
+Basta executar o script [`deploy-alerts.sh`](./deploy-alerts.sh), lembrando de configurar as variáveis no início do arquivo. Na primeira execução o Google envia um e-mail de confirmação que precisa ser aceito para o canal ficar ativo.
 
 
 

--- a/workflow/alert-policy.yaml
+++ b/workflow/alert-policy.yaml
@@ -1,0 +1,23 @@
+displayName: "cloud-cnpj - falha no workflow"
+documentation:
+  content: |
+    Um erro foi registrado durante a execução do workflow de ingestão dos dados de CNPJ.
+
+    Possíveis origens: falha do Cloud Run Job de ingestão, falha em algum Data Transfer
+    do BigQuery ou erro na própria execução do workflow.
+
+    Consulte as execuções em:
+    https://console.cloud.google.com/workflows/workflow/us-central1/cloud-cnpj/executions
+  mimeType: "text/markdown"
+combiner: OR
+conditions:
+  - displayName: "Log de erro no workflow cloud-cnpj"
+    conditionMatchedLog:
+      filter: |-
+        resource.type="workflows.googleapis.com/Workflow"
+        resource.labels.workflow_id="cloud-cnpj"
+        severity>=ERROR
+alertStrategy:
+  notificationRateLimit:
+    period: 300s
+enabled: true

--- a/workflow/cnpj-zip-bq.yaml
+++ b/workflow/cnpj-zip-bq.yaml
@@ -12,11 +12,11 @@ main:
           severity: "INFO"
           globals: ${globals}
 
-    - start_job:
+    - start_ingestion_job:
         try:
           call: googleapis.run.v1.namespaces.jobs.run
           args:
-            name: ${"namespaces/" + globals.project_id + "/jobs/" + globals.job_name}
+            name: ${"namespaces/" + globals.project_id + "/jobs/" + globals.ingestion_job_name}
             location: ${globals.location}
             connector_params:
               timeout: 43200
@@ -24,10 +24,10 @@ main:
         except:
           as: job_error
           steps:
-            - send_job_status_failure_alert:
+            - send_ingestion_job_status_failure_alert:
                 call: log_and_alert
                 args:
-                  message: ${"❌ O Cloud Run Job " + globals.job_name + " finalizou com falha."}
+                  message: ${"❌ O Cloud Run Job " + globals.ingestion_job_name + " finalizou com falha."}
                   severity: "ERROR"
                   globals: ${globals}
                 next: workflow_end
@@ -35,7 +35,7 @@ main:
     - send_job_status_success_alert:
         call: log_and_alert
         args:
-          message: ${"✅ O Cloud Run Job " + globals.job_name + " finalizou com sucesso."}
+          message: ${"✅ O Cloud Run Job " + globals.ingestion_job_name + " finalizou com sucesso e os transfers iniciaram..."}
           severity: "INFO"
           globals: ${globals}
         next: trigger_transfers
@@ -129,7 +129,27 @@ main:
         args:
           transfer_id: ${globals.scheduled_query.id}
           transfer_name: ${globals.scheduled_query.name}
-          globals: ${globals} 
+          globals: ${globals}
+
+    - start_use_job:
+        try:
+          call: googleapis.run.v1.namespaces.jobs.run
+          args:
+            name: ${"namespaces/" + globals.project_id + "/jobs/" + globals.use_job_name}
+            location: ${globals.location}
+            connector_params:
+              timeout: 43200
+          result: job_response
+        except:
+          as: job_error
+          steps:
+            - send_use_job_status_failure_alert:
+                call: log_and_alert
+                args:
+                  message: ${"❌ O Cloud Run Job " + globals.use_job_name + " finalizou com falha."}
+                  severity: "ERROR"
+                  globals: ${globals}
+                next: workflow_end
 
     - send_final_alert:
         call: log_and_alert
@@ -152,12 +172,28 @@ log_and_alert:
         args:
           text: ${message}
           severity: ${severity}
+    - check_webhook:
+        switch:
+          - condition: ${map.get(globals, "slack_webhook_url") != null and map.get(globals, "slack_webhook_url") != ""}
+            next: send_alert
+        next: exit_alert
     - send_alert:
-        call: http.post
-        args:
-          url: ${globals.slack_webhook_url}
-          body:
-            text: ${message}
+        try:
+          call: http.post
+          args:
+            url: ${globals.slack_webhook_url}
+            body:
+              text: ${message}
+        except:
+          as: alert_error
+          steps:
+            - log_alert_failure:
+                call: sys.log
+                args:
+                  text: '${"⚠️ Não foi possível enviar a notificação para o webhook - " + json.encode_to_string(alert_error)}'
+                  severity: "WARNING"
+    - exit_alert:
+        return:
 
 execute_transfer:
   params: [transfer_id, transfer_name, globals]

--- a/workflow/deploy-alerts.sh
+++ b/workflow/deploy-alerts.sh
@@ -1,0 +1,38 @@
+PROJECT="cloud-cnpj"
+ALERT_EMAIL="brunotfurtado@gmail.com"
+CHANNEL_NAME="E-mail - alertas cloud-cnpj"
+POLICY_FILE="alert-policy.yaml"
+POLICY_NAME="cloud-cnpj - falha no workflow"
+
+gcloud services enable monitoring.googleapis.com --project=$PROJECT
+
+CHANNEL=$(gcloud beta monitoring channels list \
+  --project=$PROJECT \
+  --filter="type='email' AND labels.email_address='$ALERT_EMAIL'" \
+  --format="value(name)" | head -n 1)
+
+if [ -z "$CHANNEL" ]; then
+  echo "Criando canal de notificação para $ALERT_EMAIL..."
+  CHANNEL=$(gcloud beta monitoring channels create \
+    --project=$PROJECT \
+    --display-name="$CHANNEL_NAME" \
+    --type=email \
+    --channel-labels=email_address=$ALERT_EMAIL \
+    --format="value(name)")
+  echo "⚠️  Confirme o e-mail enviado para $ALERT_EMAIL para ativar o canal."
+fi
+
+POLICY=$(gcloud alpha monitoring policies list \
+  --project=$PROJECT \
+  --filter="displayName='$POLICY_NAME'" \
+  --format="value(name)" | head -n 1)
+
+if [ -n "$POLICY" ]; then
+  echo "A política '$POLICY_NAME' já existe ($POLICY). Nada a fazer."
+  exit 0
+fi
+
+gcloud alpha monitoring policies create \
+  --project=$PROJECT \
+  --policy-from-file="$POLICY_FILE" \
+  --notification-channels="$CHANNEL"

--- a/workflow/deploy-wif.sh
+++ b/workflow/deploy-wif.sh
@@ -1,0 +1,59 @@
+PROJECT="cloud-cnpj"
+REPO="Bruno-Furtado/cloud-cnpj"
+SA="github-actions-runner"
+SA_DESCRIPTION="GitHub Actions - dispara o workflow mensal"
+POOL="github-actions"
+PROVIDER="github"
+
+SA_EMAIL="$SA@$PROJECT.iam.gserviceaccount.com"
+PROJECT_NUMBER=$(gcloud projects describe $PROJECT --format="value(projectNumber)")
+
+gcloud services enable iamcredentials.googleapis.com sts.googleapis.com --project=$PROJECT
+
+# Service account que o GitHub Actions irá personificar
+if ! gcloud iam service-accounts describe $SA_EMAIL --project=$PROJECT >/dev/null 2>&1; then
+  gcloud iam service-accounts create $SA \
+    --project=$PROJECT \
+    --display-name="$SA_DESCRIPTION"
+fi
+
+gcloud projects add-iam-policy-binding $PROJECT \
+  --member="serviceAccount:$SA_EMAIL" \
+  --role="roles/workflows.invoker" \
+  --condition=None
+
+# Pool e provider OIDC do GitHub
+if ! gcloud iam workload-identity-pools describe $POOL \
+  --project=$PROJECT --location=global >/dev/null 2>&1; then
+  gcloud iam workload-identity-pools create $POOL \
+    --project=$PROJECT \
+    --location=global \
+    --display-name="GitHub Actions"
+fi
+
+if ! gcloud iam workload-identity-pools providers describe $PROVIDER \
+  --project=$PROJECT --location=global --workload-identity-pool=$POOL >/dev/null 2>&1; then
+  gcloud iam workload-identity-pools providers create-oidc $PROVIDER \
+    --project=$PROJECT \
+    --location=global \
+    --workload-identity-pool=$POOL \
+    --display-name="GitHub" \
+    --issuer-uri="https://token.actions.githubusercontent.com" \
+    --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner" \
+    --attribute-condition="assertion.repository=='$REPO'"
+fi
+
+# Somente este repositório pode personificar a service account
+gcloud iam service-accounts add-iam-policy-binding $SA_EMAIL \
+  --project=$PROJECT \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$POOL/attribute.repository/$REPO"
+
+WIF_PROVIDER="projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$POOL/providers/$PROVIDER"
+
+echo ""
+echo "✅ Workload Identity Federation configurado. Cadastre os segredos no repositório:"
+echo ""
+echo "  gh secret set GCP_WIF_PROVIDER --body \"$WIF_PROVIDER\""
+echo "  gh secret set GCP_SA_EMAIL --body \"$SA_EMAIL\""
+echo ""

--- a/workflow/deploy.sh
+++ b/workflow/deploy.sh
@@ -1,12 +1,13 @@
 PROJECT="cloud-cnpj"
 REGION="us-central1"
-FLOW_NAME="cnpj-zip-bq"
+FLOW_NAME="cloud-cnpj"
 FILE_NAME="cnpj-zip-bq.yaml"
 DESCRIPTION="Fluxo de orquestração para ingestão e processamento dos dados de CNPJs."
 
 gcloud services enable workflows.googleapis.com --project=$PROJECT
 
 gcloud workflows deploy $FLOW_NAME \
+  --project="$PROJECT" \
   --location="$REGION" \
   --source="$FILE_NAME" \
   --description="$DESCRIPTION"


### PR DESCRIPTION
## O que muda

Hoje o workflow do GCP é executado manualmente pelo console e o badge de dados atualizados é editado à mão em dois commits todo mês. Este PR automatiza as duas coisas: um agendamento no GitHub Actions dispara o workflow no dia 15 de cada mês e atualiza os dois READMEs num único commit de bot.

## Autenticação

Usa Workload Identity Federation, sem chave de longa duração guardada neste repositório público. O `deploy-wif.sh` cria o pool, o provider OIDC restrito a `Bruno-Furtado/cloud-cnpj` e a service account com `roles/workflows.invoker`.

## Alertas

Como o Slack não está mais disponível, as falhas passam a chegar por e-mail através de uma alert policy log-based do Cloud Monitoring. O `log_and_alert` agora pula o POST quando `slack_webhook_url` está ausente e o envolve em `try/except` — antes, um webhook fora do ar abortava a execução inteira logo no primeiro step.

## Correções encontradas no caminho

O `cnpj-zip-bq.yaml` estava dessincronizado da revisão implantada: faltava o step `start_use_job` (a migração para o Firestore) e usava `job_name` em vez de `ingestion_job_name`/`use_job_name`. Foi restaurado a partir da revisão em produção, de modo que o repositório volta a refletir o que roda de verdade.

O `deploy.sh` não passava `--project`, então implantava no projeto default do gcloud, e apontava para um nome de workflow inexistente — a combinação criaria um workflow duplicado no projeto errado.

## Validação

Executado num smoke test descartável no runner real do GitHub Actions: autenticação WIF bem-sucedida, service account acessando o workflow no GCP, `sed` do badge produzindo `2026/07` nos dois READMEs no Ubuntu e payload do secret válido. O deploy do YAML corrigido foi aceito pelo GCP (revisão `000004-6b7` ativa) e o alerta por e-mail foi testado com um log `ERROR` sintético.

Falta apenas exercitar o disparo real e o push do bot, o que só é possível depois do merge, via `gh workflow run monthly-pipeline.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HGou9mKYRLpz1H7c6AEVVh