### PR TITLE
Do not print the GCP project number in the public job summary

### DIFF
--- a/.github/workflows/monthly-pipeline.yml
+++ b/.github/workflows/monthly-pipeline.yml
@@ -49,7 +49,7 @@ jobs:
             --project="$GCP_PROJECT" \
             --location="$GCP_REGION" \
             --data="$WORKFLOW_CONFIG" \
-            --format='value(name)')
+            --format='value(name.basename())')
           echo "Execução iniciada: \`$EXECUTION\`" >> "$GITHUB_STEP_SUMMARY"
           echo "Acompanhe em https://console.cloud.google.com/workflows/workflow/$GCP_REGION/$GCP_WORKFLOW/executions?project=$GCP_PROJECT" >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
O `gcloud workflows execute --format='value(name)'` devolve o nome totalmente qualificado da execução, no formato `projects/<project-number>/locations/.../executions/<id>`. Como esse valor era escrito no `$GITHUB_STEP_SUMMARY` e o repositório é público, o project number ficava visível na página do job.

Passa a imprimir apenas o identificador da execução, via `name.basename()`. O link de acompanhamento continua usando o project id, que já é público em todo o repositório.

Não é uma credencial e não dá acesso a nada sozinho, mas é informação de infraestrutura que não precisa estar num log aberto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HGou9mKYRLpz1H7c6AEVVh