### PR TITLE
Raise the fetcher job to 16Gi so ingestion stops running out of memory

### DIFF
--- a/ingestion/cnpj-data-fetcher/deploy.sh
+++ b/ingestion/cnpj-data-fetcher/deploy.sh
@@ -48,8 +48,8 @@ docker push $REGION-docker.pkg.dev/$PROJECT/$REPO_NAME/$IMAGE:latest
 JOB_FLAGS="--image $REGION-docker.pkg.dev/$PROJECT/$REPO_NAME/$IMAGE:latest \
     --region $REGION \
     --task-timeout=43200s \
-    --memory=8Gi \
-    --cpu=2 \
+    --memory=16Gi \
+    --cpu=4 \
     --max-retries=0 \
     --tasks=1 \
     --set-env-vars PROCESS=$JOB_NAME \


### PR DESCRIPTION
## O problema

A execução de julho foi morta após 1h17 com `The configured memory limit was reached` (sinal 9) enquanto processava `estabelecimentos`. A ingestão ficou pela metade — só `cnaes` e `empresas` chegaram ao bucket — e, como o `except` do `start_ingestion_job` pula direto para o fim, nenhum Data Transfer, nenhuma scheduled query e nenhuma migração para o Firestore chegaram a rodar.

## A causa

No Cloud Run o `/tmp` é um tmpfs, ou seja, mora na RAM. O fetcher baixa o ZIP em `/tmp` e extrai o CSV no mesmo lugar, então durante a extração os dois coexistem em memória. O código já é cuidadoso (streams, processamento em série, remoção do ZIP após extrair e do CSV após o upload), mas os arquivos da Receita crescem a cada mês e o pico finalmente passou de 8Gi.

## A mudança

`--memory=16Gi --cpu=4`. O patamar de 16Gi exige no mínimo 4 vCPUs no Cloud Run.

O job em produção já foi atualizado com esses valores; este PR alinha o script, para que um `deploy.sh` futuro não reverta a configuração silenciosamente.

## Limitação conhecida

Isso compra folga, não resolve a causa: o consumo continua proporcional ao tamanho dos dados e vai encostar no teto de novo. A correção estrutural é transmitir o download direto para o Cloud Storage, sem estagiar em `/tmp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HGou9mKYRLpz1H7c6AEVVh